### PR TITLE
Add scoped credentials for the Xem dashboard assistant

### DIFF
--- a/internal/api/middleware/assistant_credentials_test.go
+++ b/internal/api/middleware/assistant_credentials_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"kori/internal/assistant"
+	appdb "kori/internal/db"
+	"kori/internal/models"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAssistantCredentials(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
+	require.NoError(t, err)
+	raw, _ := db.DB()
+	t.Cleanup(func() { raw.Close() })
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.APIKey{}, &models.Resource{}, &models.ResourcePermission{}, &models.APIKeyPermission{}, &models.APIKeyUsage{}))
+	old := appdb.DB
+	appdb.DB = db
+	t.Cleanup(func() { appdb.DB = old })
+	user := models.User{Base: models.Base{ID: uuid.NewString()}, TeamID: uuid.NewString(), Role: models.UserRoleAdmin, Email: "admin@example.test", Password: "unused"}
+	require.NoError(t, db.Session(&gorm.Session{SkipHooks: true}).Create(&user).Error)
+	key, expires, err := assistant.Issue(db, user)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().Add(5*time.Minute), expires, time.Second)
+	var stored models.APIKey
+	require.NoError(t, db.Where("key = ?", assistant.Lookup(key)).First(&stored).Error)
+	require.False(t, stored.IsDeleted, "new key unexpectedly deleted; expires %v", stored.ExpiresAt)
+	require.NotEqual(t, key, stored.Key)
+	require.NotEqual(t, stored.Key, assistant.Lookup(stored.Key))
+	require.NoError(t, ValidateAPIKeyPermissions(context.Background(), db, stored.ID, []string{"contacts:read", "contacts:create", "sending:create"}))
+	require.Error(t, ValidateAPIKeyPermissions(context.Background(), db, stored.ID, []string{"api_keys:create"}))
+	require.Error(t, ValidateAPIKeyPermissions(context.Background(), db, stored.ID, []string{"users:create"}))
+	check := func(value string) error {
+		c := echo.New().NewContext(httptest.NewRequest("GET", "/api/v1/contacts", nil), httptest.NewRecorder())
+		return NewAuthMiddleware("test").validateAPIKey(c, value, func(c echo.Context) error {
+			require.Equal(t, user.TeamID, c.Get("teamID"))
+			require.Equal(t, user.ID, c.Get("userID"))
+			return nil
+		})
+	}
+	require.NoError(t, check(key))
+	require.Error(t, check(stored.Key))
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", user.ID).UpdateColumn("role", models.UserRoleMember).Error)
+	require.Error(t, check(key), "demotion must invalidate a write credential")
+	user.Role = models.UserRoleMember
+	// Legacy API-key hooks normally grant email writes. Assistant read keys
+	// must not inherit that default even when the legacy resource is present.
+	resource := models.Resource{Name: "emails", Action: "create"}
+	require.NoError(t, db.Create(&resource).Error)
+	require.NoError(t, db.Create(&models.ResourcePermission{ResourceID: resource.ID, Scope: "emails:create"}).Error)
+	readKey, _, err := assistant.Issue(db, user)
+	require.NoError(t, err)
+	var read models.APIKey
+	require.NoError(t, db.Where("key = ?", assistant.Lookup(readKey)).First(&read).Error)
+	require.NoError(t, ValidateAPIKeyPermissions(context.Background(), db, read.ID, []string{"contacts:read"}))
+	require.Error(t, ValidateAPIKeyPermissions(context.Background(), db, read.ID, []string{"contacts:create"}))
+	require.Error(t, ValidateAPIKeyPermissions(context.Background(), db, read.ID, []string{"emails:create"}))
+	require.NoError(t, check(readKey))
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", user.ID).UpdateColumn("team_id", uuid.NewString()).Error)
+	require.Error(t, check(readKey), "changing teams must invalidate old credentials")
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"kori/internal/assistant"
 	"kori/internal/db"
 	"kori/internal/models"
 	"kori/internal/utils/logger"
@@ -73,7 +74,7 @@ func (m *AuthMiddleware) Middleware() echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			return m.validateJWT(c, tokenParts[1], next)
+			return m.validateJWT(c, tokenParts[1], next, true)
 		}
 	}
 }
@@ -81,8 +82,12 @@ func (m *AuthMiddleware) Middleware() echo.MiddlewareFunc {
 func (m *AuthMiddleware) validateAPIKey(c echo.Context, key string, next echo.HandlerFunc) error {
 
 	apiKey := &models.APIKey{}
-	if err := db.DB.Where("key = ? AND is_deleted = false", key).Preload("Permissions").First(apiKey).Error; err != nil {
+	if err := db.DB.Where("key = ? AND is_deleted = false", assistant.Lookup(key)).Preload("Permissions").First(apiKey).Error; err != nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Invalid API key")
+	}
+
+	if !assistant.ValidateActor(db.DB.WithContext(c.Request().Context()), apiKey) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Assistant access has changed")
 	}
 
 	// Check expiration
@@ -96,6 +101,10 @@ func (m *AuthMiddleware) validateAPIKey(c echo.Context, key string, next echo.Ha
 	}
 
 	// Set context values
+	if apiKey.AssistantUserID != "" {
+		c.Set("userID", apiKey.AssistantUserID)
+		c.Set("assistantWrite", apiKey.AssistantWrite)
+	}
 	c.Set("teamID", apiKey.TeamID)
 	c.Set("isAPIKey", true)
 	c.Set("permissions", apiKey.Permissions)
@@ -168,7 +177,7 @@ func (m *AuthMiddleware) getResourceFromPath(path string) string {
 	return "unknown"
 }
 
-func (m *AuthMiddleware) validateJWT(c echo.Context, tokenString string, next echo.HandlerFunc) error {
+func (m *AuthMiddleware) validateJWT(c echo.Context, tokenString string, next echo.HandlerFunc, checkMethod bool) error {
 
 	claims := &Claims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
@@ -248,7 +257,7 @@ func (m *AuthMiddleware) validateJWT(c echo.Context, tokenString string, next ec
 	// Admin role has all permissions
 	if user.Role == models.UserRoleAdmin || user.Role == models.UserRoleSuperAdmin {
 		c.Set("hasAdminAccess", true)
-	} else {
+	} else if checkMethod {
 		// Check if user has the required scope
 		hasPermission := false
 		for _, scope := range claims.Scopes {
@@ -267,7 +276,7 @@ func (m *AuthMiddleware) validateJWT(c echo.Context, tokenString string, next ec
 	c.Set("userID", claims.UserID)
 	c.Set("teamID", claims.TeamID)
 	c.Set("email", claims.Email)
-	c.Set("role", claims.Role)
+	c.Set("role", string(user.Role))
 	c.Set("scopes", claims.Scopes)
 	c.Set("isAPIKey", false)
 
@@ -335,4 +344,18 @@ func HasPermission(c echo.Context, requiredScope string) bool {
 		}
 	}
 	return false
+}
+
+// SessionMiddleware authenticates a current human membership. The dedicated
+// credential handler derives read/write scope itself; API keys cannot mint keys.
+func (m *AuthMiddleware) SessionMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			parts := strings.Split(c.Request().Header.Get("Authorization"), " ")
+			if len(parts) != 2 || parts[0] != "Bearer" || c.Request().Header.Get("X-API-Key") != "" {
+				return echo.NewHTTPError(401, "Sign in required")
+			}
+			return m.validateJWT(c, parts[1], next, false)
+		}
+	}
 }

--- a/internal/assistant/credentials.go
+++ b/internal/assistant/credentials.go
@@ -1,0 +1,78 @@
+package assistant
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"kori/internal/models"
+)
+
+const Prefix = "xem_bot_"
+
+// Lookup keeps assistant credentials irreversible at rest. Legacy customer keys
+// retain their existing representation.
+func Lookup(key string) string {
+	if strings.HasPrefix(key, "bot_sha256:") {
+		return "invalid-assistant-key"
+	}
+	if !strings.HasPrefix(key, Prefix) {
+		return key
+	}
+	sum := sha256.Sum256([]byte(key))
+	return "bot_sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ValidateActor(db *gorm.DB, key *models.APIKey) bool {
+	if key.AssistantUserID == "" {
+		return !strings.HasPrefix(key.Key, "bot_sha256:")
+	}
+	var user models.User
+	if db.Where("id = ? AND team_id = ? AND is_deleted = false", key.AssistantUserID, key.TeamID).First(&user).Error != nil {
+		return false
+	}
+	return !key.AssistantWrite || user.Role == models.UserRoleAdmin || user.Role == models.UserRoleSuperAdmin
+}
+
+// Issue grants only product resources. Keys cannot administer other credentials,
+// users, billing, or operator approvals. Every MCP call still checks permissions.
+func Issue(db *gorm.DB, user models.User) (string, time.Time, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", time.Time{}, err
+	}
+	secret := Prefix + hex.EncodeToString(raw)
+	expiry := time.Now().UTC().Add(5 * time.Minute)
+	write := user.Role == models.UserRoleAdmin || user.Role == models.UserRoleSuperAdmin
+	key := models.APIKey{Name: "Xem assistant (short-lived)", Key: Lookup(secret), TeamID: user.TeamID, ExpiresAt: expiry, AssistantUserID: user.ID, AssistantWrite: write}
+	resources := []string{"campaigns", "contacts", "lists", "templates", "smtp_configs", "analytics", "emails", "marketing", "forms", "automations", "domains", "tags", "webhooks", "sending"}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&key).Error; err != nil {
+			return err
+		}
+		action := "read"
+		if write {
+			action = "admin"
+		}
+		for _, name := range resources {
+			var resource models.Resource
+			if err := tx.Where("name = ? AND action = ? AND is_deleted = false", name, action).FirstOrCreate(&resource, models.Resource{Name: name, Action: action}).Error; err != nil {
+				return err
+			}
+			var permission models.ResourcePermission
+			if err := tx.Where("resource_id = ? AND is_deleted = false", resource.ID).FirstOrCreate(&permission, models.ResourcePermission{ResourceID: resource.ID, Scope: action + ":" + name}).Error; err != nil {
+				return err
+			}
+			if err := tx.Create(&models.APIKeyPermission{KeyID: key.ID, ResourcePermissionID: permission.ID}).Error; err != nil {
+				return err
+			}
+		}
+		// Keep audit usage, but remove expired credential grants so idle workspaces do
+		// not accumulate one active key per chat turn.
+		return tx.Model(&models.APIKey{}).Where("assistant_user_id = ? AND expires_at < ?", user.ID, time.Now().UTC()).Update("is_deleted", true).Error
+	})
+	return secret, expiry, err
+}

--- a/internal/handlers/mcp_auth_handler.go
+++ b/internal/handlers/mcp_auth_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
+	"kori/internal/assistant"
 	"kori/internal/models"
 )
 
@@ -19,13 +20,16 @@ func MCPAuthorize(db *gorm.DB) echo.HandlerFunc {
 		if key == "" || len(key) > 4096 {
 			return echo.NewHTTPError(http.StatusUnauthorized, "Invalid API key")
 		}
-		var count int64
+		var row models.APIKey
 		if err := db.WithContext(c.Request().Context()).Model(&models.APIKey{}).
-			Where("key = ? AND is_deleted = false AND team_id IS NOT NULL", key).
-			Where("expires_at IS NULL OR expires_at = ? OR expires_at > ?", time.Time{}, time.Now()).Count(&count).Error; err != nil {
+			Where("key = ? AND is_deleted = false AND team_id IS NOT NULL", assistant.Lookup(key)).
+			Where("expires_at IS NULL OR expires_at = ? OR expires_at > ?", time.Time{}, time.Now().UTC()).First(&row).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return echo.NewHTTPError(401, "Invalid API key")
+			}
 			return echo.NewHTTPError(503, "Authentication unavailable")
 		}
-		if count != 1 {
+		if !assistant.ValidateActor(db.WithContext(c.Request().Context()), &row) {
 			return echo.NewHTTPError(http.StatusUnauthorized, "Invalid API key")
 		}
 		return c.NoContent(http.StatusNoContent)

--- a/internal/models/hooks.go
+++ b/internal/models/hooks.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (a *APIKey) AfterCreate(tx *gorm.DB) error {
+	if a.AssistantUserID != "" {
+		return nil
+	}
 
 	// 🔍 Get resources for read and create actions
 	var resources []Resource

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -418,14 +418,16 @@ type EmailTracking struct {
 
 type APIKey struct {
 	Base
-	Name        string             `gorm:"not null" json:"name"`
-	Key         string             `gorm:"not null" json:"key"`
-	TeamID      string             `gorm:"type:uuid;not null" json:"teamId" validate:"required,uuid"`
-	Team        *Team              `json:"team,omitempty"`
-	CreatedAt   time.Time          `json:"createdAt"`
-	LastUsedAt  time.Time          `json:"lastUsedAt"`
-	ExpiresAt   time.Time          `json:"expiresAt"`
-	Permissions []APIKeyPermission `gorm:"foreignKey:KeyID" json:"permissions,omitempty"`
+	AssistantUserID string             `gorm:"index" json:"-"`
+	AssistantWrite  bool               `json:"-"`
+	Name            string             `gorm:"not null" json:"name"`
+	Key             string             `gorm:"not null" json:"key"`
+	TeamID          string             `gorm:"type:uuid;not null" json:"teamId" validate:"required,uuid"`
+	Team            *Team              `json:"team,omitempty"`
+	CreatedAt       time.Time          `json:"createdAt"`
+	LastUsedAt      time.Time          `json:"lastUsedAt"`
+	ExpiresAt       time.Time          `json:"expiresAt"`
+	Permissions     []APIKeyPermission `gorm:"foreignKey:KeyID" json:"permissions,omitempty"`
 }
 
 func (a *APIKey) BeforeCreate(tx *gorm.DB) error {

--- a/internal/routes/marketing_routes.go
+++ b/internal/routes/marketing_routes.go
@@ -7,13 +7,30 @@ import (
 	"gorm.io/gorm"
 	"kori/internal/ai"
 	"kori/internal/api/middleware"
+	"kori/internal/assistant"
 	"kori/internal/config"
 	"kori/internal/handlers"
+	"kori/internal/models"
 	"os"
 )
 
 func SetupMarketingRoutes(e *echo.Echo, db *gorm.DB, cfg *config.Config) {
 	e.GET("/api/v1/mcp/authorize", handlers.MCPAuthorize(db), em.RateLimiter(em.NewRateLimiterMemoryStore(rate.Limit(10))))
+	e.POST("/api/v1/assistant/credential", func(c echo.Context) error {
+		var user models.User
+		if db.WithContext(c.Request().Context()).Where("id = ? AND team_id = ? AND is_deleted = false", c.Get("userID"), c.Get("teamID")).First(&user).Error != nil {
+			return echo.NewHTTPError(401, "Sign in required")
+		}
+		key, expires, err := assistant.Issue(db.WithContext(c.Request().Context()), user)
+		if err != nil {
+			return echo.NewHTTPError(503, "Assistant access unavailable")
+		}
+		c.Response().Header().Set("Cache-Control", "no-store")
+		return c.JSON(200, map[string]interface{}{"key": key, "expiresAt": expires, "teamId": user.TeamID, "userId": user.ID, "canWrite": user.Role == models.UserRoleAdmin || user.Role == models.UserRoleSuperAdmin})
+	}, em.BodyLimit("1K"), middleware.NewAuthMiddleware(cfg.JWT.Secret).SessionMiddleware(), em.RateLimiterWithConfig(em.RateLimiterConfig{
+		Store:               em.NewRateLimiterMemoryStoreWithConfig(em.RateLimiterMemoryStoreConfig{Rate: rate.Limit(.5), Burst: 10}),
+		IdentifierExtractor: func(c echo.Context) (string, error) { return c.Get("userID").(string), nil },
+	}))
 	h := handlers.NewMarketingHandler(db, cfg.JWT.Secret, os.Getenv("PUBLIC_API_URL"))
 	g := e.Group("/api/v1/marketing", middleware.NewAuthMiddleware(cfg.JWT.Secret).Middleware())
 	endpoint := os.Getenv("AI_PROXY_BASE_URL")

--- a/internal/sending/http.go
+++ b/internal/sending/http.go
@@ -24,7 +24,13 @@ func admin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		api, _ := c.Get("isAPIKey").(bool)
 		allowed, _ := c.Get("hasAdminAccess").(bool)
-		if api || !allowed || uuid.Validate(workspace(c)) != nil {
+		assistantWrite, _ := c.Get("assistantWrite").(bool)
+		// Assistant credentials can inspect and manage sending, but never mint
+		// reusable SMTP secrets. They have already passed actor and scope checks.
+		if api {
+			allowed = assistantWrite && !(c.Request().Method == "POST" && strings.HasSuffix(c.Path(), "/credentials"))
+		}
+		if (api && !assistantWrite) || !allowed || uuid.Validate(workspace(c)) != nil {
 			return echo.NewHTTPError(403, "Workspace administrator access is required")
 		}
 		return next(c)

--- a/internal/sending/transport_test.go
+++ b/internal/sending/transport_test.go
@@ -158,3 +158,28 @@ func TestRecoveryUpdatesSourceEmailAndExpiresQueuedContent(t *testing.T) {
 		})
 	}
 }
+
+func TestAssistantSendingAccessCannotMintCredentials(t *testing.T) {
+	for _, item := range []struct {
+		path    string
+		write   bool
+		allowed bool
+	}{
+		{"/api/v1/sending", true, true},
+		{"/api/v1/sending/pause", true, true},
+		{"/api/v1/sending/credentials", true, false},
+		{"/api/v1/sending", false, false},
+	} {
+		c := echo.New().NewContext(httptest.NewRequest("POST", item.path, nil), httptest.NewRecorder())
+		c.SetPath(item.path)
+		c.Set("teamID", uuid.NewString())
+		c.Set("isAPIKey", true)
+		c.Set("assistantWrite", item.write)
+		called := false
+		err := admin(func(echo.Context) error { called = true; return nil })(c)
+		require.Equal(t, item.allowed, called)
+		if !item.allowed {
+			require.Error(t, err)
+		}
+	}
+}


### PR DESCRIPTION
Allow the Next.js dashboard assistant to use hosted MCP with a five-minute credential bound to the signed-in user and workspace. Store only its SHA-256 digest; recheck current membership, admin role, expiry and revocation on API/MCP requests. Members receive read grants and do not inherit the legacy default email-write permission.

Admin-bound assistant credentials can inspect and manage sending readiness through the existing policy gates, but cannot mint reusable SMTP secrets, administer developer keys/users/billing, or grant operator sending approval. AI prompts, streaming, conversation storage and review execution live in the companion Next.js change.

Validation: affected middleware, handler and sending tests pass with the Go race detector, including stored-digest rejection, member scopes, demotion/team changes, and SMTP-credential denial. `go vet` for affected packages and `go build ./...` also pass. Existing full-suite AI test-compilation and Cori App configuration failures are outside this change. No app rollout is performed by this PR.

Companion PRs: [Dashboard](https://github.com/mailxem/xem-app.ts/pull/5), [MCP](https://github.com/mailxem/mcp/pull/6), [Website](https://github.com/mailxem/xem-website/pull/3).
